### PR TITLE
feat (battle notes): add locally stored battle notes field

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -476,6 +476,12 @@ table.field {
     resize: vertical;
 }
 
+.battle-notes-text {
+    min-width: 27em;
+    min-height: 10em;
+    resize: vertical;
+}
+
 .import-name-text {
 	min-width: 26.3em;
     min-height: 1em;

--- a/index.html
+++ b/index.html
@@ -1099,7 +1099,7 @@
                     <form class="import-team">
                         <input class="import-name-text" value="Custom Set"></input>
                         <textarea class="import-team-text"></textarea>
-                        <button class='bs-btn bs-btn-default'>Import</button>
+                        <!-- <button class='bs-btn bs-btn-default'>Import</button> -->
                     </form>
                 </div>
             </fieldset>

--- a/index.html
+++ b/index.html
@@ -1085,8 +1085,8 @@
         <div aria-label="Battle Notes" role="region">
             <fieldset class="poke-import">
                 <legend align="center">Battle Notes</legend>
-                <div id="import-1_wrapper" class="dataTables_wrapper no-footer">
-                    <form class="import-team">
+                <div id="battle_notes_wrapper" class="dataTables_wrapper no-footer">
+                    <form class="battle_notes">
                         <textarea class="battle-notes-text"></textarea>
                     </form>
                 </div>

--- a/index.html
+++ b/index.html
@@ -1094,6 +1094,16 @@
                 </div>
             </fieldset>
         </div>
+        <div aria-label="Battle Notes" role="region">
+            <fieldset class="poke-import">
+                <legend align="center">Battle Notes</legend>
+                <div id="import-1_wrapper" class="dataTables_wrapper no-footer">
+                    <form class="import-team">
+                        <textarea class="battle-notes-text"></textarea>
+                    </form>
+                </div>
+            </fieldset>
+        </div>
     </div>
     <div class="panel">
         <div aria-label="Pok&eacute;mon 2" role="region">

--- a/index.html
+++ b/index.html
@@ -1099,7 +1099,7 @@
                     <form class="import-team">
                         <input class="import-name-text" value="Custom Set"></input>
                         <textarea class="import-team-text"></textarea>
-                        <!--<button style='position:absolute' class='bs-btn bs-btn-default'>Import</button>-->
+                        <button class='bs-btn bs-btn-default'>Import</button>
                     </form>
                 </div>
             </fieldset>

--- a/index.html
+++ b/index.html
@@ -1082,6 +1082,16 @@
                 </table>
             </fieldset>
         </div>
+        <div aria-label="Battle Notes" role="region">
+            <fieldset class="poke-import">
+                <legend align="center">Battle Notes</legend>
+                <div id="import-1_wrapper" class="dataTables_wrapper no-footer">
+                    <form class="import-team">
+                        <textarea class="battle-notes-text"></textarea>
+                    </form>
+                </div>
+            </fieldset>
+        </div>
         <div aria-label="Import team" role="region">
             <fieldset class="poke-import">
                 <legend align="center">Import / Export</legend>
@@ -1090,16 +1100,6 @@
                         <input class="import-name-text" value="Custom Set"></input>
                         <textarea class="import-team-text"></textarea>
                         <!--<button style='position:absolute' class='bs-btn bs-btn-default'>Import</button>-->
-                    </form>
-                </div>
-            </fieldset>
-        </div>
-        <div aria-label="Battle Notes" role="region">
-            <fieldset class="poke-import">
-                <legend align="center">Battle Notes</legend>
-                <div id="import-1_wrapper" class="dataTables_wrapper no-footer">
-                    <form class="import-team">
-                        <textarea class="battle-notes-text"></textarea>
                     </form>
                 </div>
             </fieldset>

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -1809,6 +1809,7 @@ function switchIconDouble(){
 }
 
 $(document).ready(function () {
+	fillBattleNotes();
 	var params = new URLSearchParams(window.location.search);
 	var g = GENERATION[params.get('gen')] || 9;
 	$("#gen" + g).prop("checked", true);
@@ -1863,4 +1864,17 @@ $("#mainResult").click(function () {
 			document.getElementById('tooltipText').style.visibility = 'hidden';
 		}, 2000);
 	});
+});
+
+function fillBattleNotes(){
+	let lastNotes = localStorage.getItem("pklucid_battlenotes");
+	if (lastNotes != ""){
+		lastNotes = JSON.parse(lastNotes);
+		$(".battle-notes-text").val(lastNotes);
+	}
+}
+
+$(".battle-notes-text").on("blur", function(){
+	let notes = JSON.stringify($(this).val());
+	localStorage.setItem("pklucid_battlenotes", notes);
 });


### PR DESCRIPTION
Feature requested by maximegr on discord, adding a locally stored Battle Notes field to the calc that persists across sessions. Simple textarea that saves on blur and loads out of local storage on page load.